### PR TITLE
fix: a proper way to retrieve env vars

### DIFF
--- a/src/components/SetAddress.vue
+++ b/src/components/SetAddress.vue
@@ -120,7 +120,7 @@ export default {
     _reverseGeoCode: async function (loc) {
       const resp = await axios.get("https://api.nextbillion.io/h/revgeocode", {
         params: {
-          key: process.env.NEXTBILLION_API_KEY,
+          key: import.meta.env.VITE_NEXTBILLION_API_KEY,
           at: `${loc.lat},${loc.lng}`,
         },
       });
@@ -140,7 +140,7 @@ export default {
     discover: async function () {
       const resp = await axios.get("https://api.nextbillion.io/h/discover", {
         params: {
-          key: process.env.NEXTBILLION_API_KEY,
+          key: import.meta.env.VITE_NEXTBILLION_API_KEY,
           q: this.q,
           at: `${this.userLocation.lat},${this.userLocation.lng}`,
         },

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,8 @@ import "./assets/main.css";
 import App from "./App.vue";
 import router from "./router";
 
-nextbillion.setApiKey(process.env.NEXTBILLION_API_KEY);
-nextbillion.setApiHost(process.env.NEXTBILLION_API_HOST);
+nextbillion.setApiKey(import.meta.env.VITE_NEXTBILLION_API_KEY);
+nextbillion.setApiHost(import.meta.env.VITE_NEXTBILLION_API_HOST);
 
 
 const app = createApp(App);


### PR DESCRIPTION
Hi this is Yun from NextBillion.ai. This PR is about the blog post review. Modified the places where `import.meta.env` is required rather than `process.env` which can cause a JS runtime error in the browser.